### PR TITLE
locate VDSO by calling libc::getauxval

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,6 @@ maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "enarx/vdso" }
 is-it-maintained-open-issues = { repository = "enarx/vdso" }
 
-[dev-dependencies]
-libc = "0.2.67"
-
 [dependencies]
-crt0stack = "0.1"
 goblin = "0.6.0"
+libc = "0.2.67"


### PR DESCRIPTION
This is preferred as crt0stack::Reader::from_environ() relies on the global environ pointer and:
1. The environ pointer is not guaranteed to point to memory before auxv by any standard I am aware of. It just happens to do so in some C library implementations if the environment has not been modified.
2. The environ pointer is definitely not going to point to memory before auxv after calling any environment modifying function such as setenv(3).

Calling getauxval(3) is the only standards compliant way of accessing values in the auxiliary vector.