### PR TITLE
feat: use `libc::getauxval`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ description = "Resolve Linux vDSO symbols"
 readme = "README.md"
 keywords = ["linux", "vdso"]
 categories = ["development-tools", "os::linux-apis"]
-exclude = [ ".gitignore", ".github/*" ]
+exclude = [".gitignore", ".github/*"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -23,9 +23,6 @@ maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "enarx/vdso" }
 is-it-maintained-open-issues = { repository = "enarx/vdso" }
 
-[dev-dependencies]
-libc = "0.2.67"
-
 [dependencies]
-crt0stack = "0.1"
 goblin = "0.8.0"
+libc = "0.2.153"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@
 #![deny(missing_docs)]
 #![deny(clippy::all)]
 
-use crt0stack::{Entry, Reader};
 use std::ffi::CStr;
 use std::os::raw::c_char;
 use std::slice::from_raw_parts;
@@ -20,6 +19,7 @@ mod elf {
     pub use goblin::elf64::sym::Sym;
 
     pub const CLASS: u8 = ELFCLASS64;
+
     pub type Word = u64;
 }
 
@@ -33,6 +33,7 @@ mod elf {
     pub use goblin::elf32::sym::Sym;
 
     pub const CLASS: u8 = ELFCLASS32;
+
     pub type Word = u32;
 }
 
@@ -114,14 +115,13 @@ pub struct Vdso<'a>(&'a Header);
 impl Vdso<'static> {
     /// Locates the vDSO by parsing the auxiliary vectors
     pub fn locate() -> Option<Self> {
-        for aux in Reader::from_environ().done() {
-            if let Entry::SysInfoEHdr(addr) = aux {
-                let hdr = unsafe { Header::from_ptr(&*(addr as *const _))? };
-                return Some(Self(hdr));
-            }
+        let val = unsafe { libc::getauxval(libc::AT_SYSINFO_EHDR) };
+        if val == 0 {
+            return None;
         }
 
-        None
+        let hdr = unsafe { Header::from_ptr(&*(val as *const _))? };
+        Some(Self(hdr))
     }
 }
 


### PR DESCRIPTION
This is preferred as crt0stack::Reader::from_environ() relies on the global environ pointer and:

1. The environ pointer is not guaranteed to point to memory before auxv by any standard I am aware of. It just happens to do so in some C library implementations if the environment has not been modified.
2. The environ pointer is definitely not going to point to memory before auxv after calling any environment modifying function such as setenv(3).

Calling getauxval(3) is the only standards compliant way of accessing values in the auxiliary vector.

Dup of #20 since it has conflicts and tests weren't running.